### PR TITLE
Add utility to get ambertools version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.9]
+        amber-tools: [false, true]
+
     env:
       CI_OS: ${{ matrix.os }}
       PYVER: ${{ matrix.python-version }}
@@ -44,6 +46,19 @@ jobs:
         uname -a
         df -h
         ulimit -a
+
+    - name: Install AmberTools
+      if: matrix.amber-tools == true
+      shell: bash -l {0}
+      run: |
+        conda install --yes -c conda-forge ambertools
+        python -c "from shutil import which; assert which('sqm') is not None"
+
+    - name: Check AmberTools Missing
+      if: matrix.amber-tools == false
+      shell: bash -l {0}
+      run: |
+        python -c "from shutil import which; assert which('sqm') is None"
 
     - name: Environment Information
       shell: bash -l {0}

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -11,3 +11,4 @@ dependencies:
   - pytest-cov
   - codecov
   - mypy
+  - types-setuptools

--- a/openff/utilities/provenance.py
+++ b/openff/utilities/provenance.py
@@ -1,0 +1,33 @@
+import functools
+import re
+import subprocess
+from typing import Dict, Optional
+
+import pkg_resources
+
+
+@functools.lru_cache()
+def _get_conda_list_package_versions() -> Dict[str, str]:
+    """Returns the versions of any packages found while executing `conda list`."""
+
+    list_output = subprocess.check_output(["conda", "list"]).decode().split("\n")
+
+    package_versions = {}
+
+    for output_line in list_output[3:-1]:
+
+        package_name, package_version, *_ = re.split(" +", output_line)
+        package_versions[package_name] = package_version
+
+    return package_versions
+
+
+def get_ambertools_version() -> Optional[str]:
+    """Attempts to retrieve the version of the currently installed AmberTools."""
+
+    try:
+        distribution = pkg_resources.get_distribution("AmberTools")
+        return distribution.version
+
+    except pkg_resources.DistributionNotFound:
+        return _get_conda_list_package_versions().get("ambertools", None)

--- a/openff/utilities/tests/test_provenance.py
+++ b/openff/utilities/tests/test_provenance.py
@@ -1,0 +1,24 @@
+import importlib
+
+import pytest
+
+from openff.utilities.provenance import get_ambertools_version
+
+
+def test_get_ambertools_version_found():
+
+    # Skip if ambertools is not installed.
+    pytest.importorskip("parmed")
+
+    assert get_ambertools_version() is not None
+
+
+def test_get_ambertools_version_not_found():
+
+    try:
+        importlib.import_module("parmed")
+    except ImportError:
+        assert get_ambertools_version() is None
+        return
+
+    pytest.skip("only run when ambertools is not installed.")


### PR DESCRIPTION
## Description

This PR adds a convenience method for querying the version of ambertools if it is installed. This method is not 100% foolproof, but should in most cases give access to a version for AT.

## Status
- [ ] Ready to go