### PR TITLE
Improve module loading times

### DIFF
--- a/openff/utilities/provenance.py
+++ b/openff/utilities/provenance.py
@@ -3,8 +3,6 @@ import re
 import subprocess
 from typing import Dict, Optional
 
-import pkg_resources
-
 
 @functools.lru_cache()
 def _get_conda_list_package_versions() -> Dict[str, str]:
@@ -25,9 +23,4 @@ def _get_conda_list_package_versions() -> Dict[str, str]:
 def get_ambertools_version() -> Optional[str]:
     """Attempts to retrieve the version of the currently installed AmberTools."""
 
-    try:
-        distribution = pkg_resources.get_distribution("AmberTools")
-        return distribution.version
-
-    except pkg_resources.DistributionNotFound:
-        return _get_conda_list_package_versions().get("ambertools", None)
+    return _get_conda_list_package_versions().get("ambertools", None)

--- a/openff/utilities/testing.py
+++ b/openff/utilities/testing.py
@@ -1,7 +1,5 @@
 from typing import List, Optional, Union
 
-import pytest
-
 from openff.utilities.utilities import has_executable, has_package
 
 
@@ -23,6 +21,8 @@ def skip_if_missing(package_name: str, reason: Optional[str] = None):
     requires_package : _pytest.mark.structures.MarkDecorator
         A pytest decorator that will skip tests if the package is not available
     """
+    import pytest
+
     if not reason:
         reason = f"Package {package_name} is required, but was not found."
     requires_package = pytest.mark.skipif(not has_package(package_name), reason=reason)
@@ -32,6 +32,8 @@ def skip_if_missing(package_name: str, reason: Optional[str] = None):
 def skip_if_missing_exec(exec: Union[str, List[str]]):
     """Helper function to generate a pytest.mark.skipif decorator
     if an executable(s) is not found."""
+    import pytest
+
     if isinstance(exec, str):
         execs: List = [exec]
     elif isinstance(exec, list):

--- a/openff/utilities/utilities.py
+++ b/openff/utilities/utilities.py
@@ -204,10 +204,11 @@ def get_data_file_path(relative_path: str, package_name: str) -> str:
     ------
     FileNotFoundError
     """
+    import importlib_resources
 
-    from pkg_resources import resource_filename
-
-    file_path = resource_filename(package_name, os.path.join("data", relative_path))
+    file_path = importlib_resources.files(package_name) / os.path.join(
+        "data", relative_path
+    )
 
     if not os.path.exists(file_path):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), file_path)


### PR DESCRIPTION
## Description
While packaging the last version, I noticed I added several deps that slow things down.

* Lazy-load `pytest` so other functions can be imported without it being installed
* Fix a logical check for an AmberTools distribution that will always fail
* Use `importlib_resources` because `pkg_resources` is slow:

```
$ time python -c "import pkg_resources"
python -c "import pkg_resources"  0.24s user 0.11s system 92% cpu 0.383 total
$ time python -c "import importlib_resources"
python -c "import importlib_resources"  0.06s user 0.04s system 77% cpu 0.120 total
```