### PR TITLE
Fix formatting of `conda install` suggestion

### DIFF
--- a/openff/utilities/exceptions.py
+++ b/openff/utilities/exceptions.py
@@ -36,8 +36,8 @@ class MissingOptionalDependency(OpenFFException):
 
         if "openeye" not in library_name:
             message = (
-                f"{message} Try installing the package by running"
-                f"`conda install -c conda-forge {library_name_corrected}"
+                f"{message} Try installing the package by running "
+                f"`conda install -c conda-forge {library_name_corrected}`"
             )
 
         super(MissingOptionalDependency, self).__init__(message)


### PR DESCRIPTION
In https://github.com/openforcefield/openff-units/pull/34#issuecomment-1145352131 I noticed weird formatting of the `conda install ...` line. Now:

```python3
>>> from openff.utilities import requires_package
>>>
>>> @requires_package("foo")
... def f():
...     return 0
...
>>> f()
Traceback (most recent call last):
  File "/Users/mattthompson/software/openff-utilities/openff/utilities/utilities.py", line 69, in wrapper
    importlib.import_module(package_name)
  File "/Users/mattthompson/miniconda3/envs/openff-units-test/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'foo'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mattthompson/software/openff-utilities/openff/utilities/utilities.py", line 71, in wrapper
    raise MissingOptionalDependency(library_name=package_name)
openff.utilities.exceptions.MissingOptionalDependency: The required foo module could not be imported. Try installing the package by running `conda install -c conda-forge foo`