### PR TITLE
Update exception names

### DIFF
--- a/openff/utilities/exceptions.py
+++ b/openff/utilities/exceptions.py
@@ -2,7 +2,7 @@ class OpenFFException(BaseException):
     """The base exception from which most custom exceptions in openff-utilities should inherit."""
 
 
-class MissingOptionalDependency(OpenFFException):
+class MissingOptionalDependencyError(OpenFFException):
     """An exception raised when an optional dependency is required
     but cannot be found.
 
@@ -40,7 +40,16 @@ class MissingOptionalDependency(OpenFFException):
                 f"`conda install -c conda-forge {library_name_corrected}`"
             )
 
-        super(MissingOptionalDependency, self).__init__(message)
+        super(MissingOptionalDependencyError, self).__init__(message)
 
         self.library_name = library_name
         self.license_issue = license_issue
+
+
+class MissingOptionalDependency(MissingOptionalDependencyError):
+    import warnings
+
+    warnings.warn(
+        "MissingOptionalDependency is deprecated. Use MissingOptionalDependencyError instead.",
+        DeprecationWarning,
+    )

--- a/openff/utilities/exceptions.py
+++ b/openff/utilities/exceptions.py
@@ -1,8 +1,8 @@
-class OpenFFException(BaseException):
+class OpenFFError(BaseException):
     """The base exception from which most custom exceptions in openff-utilities should inherit."""
 
 
-class MissingOptionalDependencyError(OpenFFException):
+class MissingOptionalDependencyError(OpenFFError):
     """An exception raised when an optional dependency is required
     but cannot be found.
 

--- a/openff/utilities/tests/test_exceptions.py
+++ b/openff/utilities/tests/test_exceptions.py
@@ -3,7 +3,7 @@ import pytest
 from openff.utilities.exceptions import (
     MissingOptionalDependency,
     MissingOptionalDependencyError,
-    OpenFFException,
+    OpenFFError,
 )
 
 
@@ -20,7 +20,7 @@ def test_exceptions():
     ):
         raise MissingOptionalDependencyError(library_name="barbaz", license_issue=True)
 
-    with pytest.raises(OpenFFException):
+    with pytest.raises(OpenFFError):
         raise MissingOptionalDependencyError("numpy")
 
 

--- a/openff/utilities/tests/test_exceptions.py
+++ b/openff/utilities/tests/test_exceptions.py
@@ -1,18 +1,30 @@
 import pytest
 
-from openff.utilities.exceptions import MissingOptionalDependency, OpenFFException
+from openff.utilities.exceptions import (
+    MissingOptionalDependency,
+    MissingOptionalDependencyError,
+    OpenFFException,
+)
 
 
 def test_exceptions():
     with pytest.raises(
-        MissingOptionalDependency,
+        MissingOptionalDependencyError,
         match="The required foobar module could not be imported.*"
         "Try installing.*conda-forge.*",
     ):
-        raise MissingOptionalDependency(library_name="foobar")
+        raise MissingOptionalDependencyError(library_name="foobar")
 
-    with pytest.raises(MissingOptionalDependency, match=".*barbaz.*missing license."):
-        raise MissingOptionalDependency(library_name="barbaz", license_issue=True)
+    with pytest.raises(
+        MissingOptionalDependencyError, match=".*barbaz.*missing license."
+    ):
+        raise MissingOptionalDependencyError(library_name="barbaz", license_issue=True)
 
     with pytest.raises(OpenFFException):
-        raise MissingOptionalDependency("numpy")
+        raise MissingOptionalDependencyError("numpy")
+
+
+def test_missing_optional_dependency_deprecation():
+    with pytest.raises(MissingOptionalDependency):
+        with pytest.warns(UserWarning, match="DEP"):
+            raise MissingOptionalDependency("foobar")

--- a/openff/utilities/tests/test_utilities.py
+++ b/openff/utilities/tests/test_utilities.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from openff.utilities.exceptions import MissingOptionalDependency
+from openff.utilities.exceptions import MissingOptionalDependencyError
 from openff.utilities.testing import skip_if_missing
 from openff.utilities.utilities import (
     get_data_file_path,
@@ -107,7 +107,7 @@ def test_requires_package():
     # sys should always be found so this should not raise an exception.
     requires_package("sys")(dummy_function)()
 
-    with pytest.raises(MissingOptionalDependency) as error_info:
+    with pytest.raises(MissingOptionalDependencyError) as error_info:
         requires_package("fake-lib")(dummy_function)()
 
     assert error_info.value.library_name == "fake-lib"
@@ -137,7 +137,7 @@ def test_requires_oe_module_installed_missing_license():
     def dummy_function():
         pass
 
-    with pytest.raises(MissingOptionalDependency) as error_info:
+    with pytest.raises(MissingOptionalDependencyError) as error_info:
         requires_oe_module("oechem")(dummy_function)()
 
     assert "oechem" in str(error_info.value)
@@ -154,7 +154,7 @@ def test_requires_oe_module_not_installed():
     def dummy_function():
         pass
 
-    with pytest.raises(MissingOptionalDependency) as error_info:
+    with pytest.raises(MissingOptionalDependencyError) as error_info:
         requires_oe_module("oechem")(dummy_function)()
 
     assert "oechem" in str(error_info.value)

--- a/openff/utilities/utilities.py
+++ b/openff/utilities/utilities.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from typing_extensions import Literal
 
-from openff.utilities.exceptions import MissingOptionalDependency
+from openff.utilities.exceptions import MissingOptionalDependencyError
 
 
 def has_package(package_name: str):
@@ -46,7 +46,7 @@ def requires_package(package_name: str):
     """
     Helper function to denote that a funciton requires some optional
     dependency. A function decorated with this decorator will raise
-    `MissingDependencyError` if the package is not found by
+    `MissingOptionalDependencyError` if the package is not found by
     `importlib.import_module()`.
 
     Parameters
@@ -56,7 +56,7 @@ def requires_package(package_name: str):
 
     Raises
     ------
-    MissingDependencyError
+    MissingOptionalDependencyError
 
     """
 
@@ -68,7 +68,7 @@ def requires_package(package_name: str):
             try:
                 importlib.import_module(package_name)
             except ImportError:
-                raise MissingOptionalDependency(library_name=package_name)
+                raise MissingOptionalDependencyError(library_name=package_name)
             except Exception as e:
                 raise e
 
@@ -84,7 +84,7 @@ def requires_oe_module(
 ):
     """
     Helper function to denote that a funciton requires a particular OpenEye library.
-    A function decorated with this decorator will raise `MissingDependencyError` if
+    A function decorated with this decorator will raise `MissingOptionalDependencyError` if
     the module is not found by @requires_package or the module is not found to be
     licensed.
 
@@ -95,7 +95,7 @@ def requires_oe_module(
 
     Raises
     ------
-    MissingDependencyError
+    MissingOptionalDependencyError
     """
 
     def inner_decorator(function):
@@ -115,7 +115,7 @@ def requires_oe_module(
             is_licensed = getattr(oe_module, license_functions[module_name])()
 
             if not is_licensed:
-                raise MissingOptionalDependency(
+                raise MissingOptionalDependencyError(
                     library_name=f"openeye.{module_name}", license_issue=True
                 )
 


### PR DESCRIPTION
## Description
An attempt at nipping in the bud an aesthetic inconsistency.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Ensure all exceptions are named `.*Error`

```shell
(openff-dev) [openff-utilities] grep -r "^class .*E" openff/utilities                                        9:00:29  ☁  error-name ☂ ✭
openff/utilities/_version.py:class NotThisMethod(Exception):
openff/utilities/exceptions.py:class OpenFFError(BaseException):
openff/utilities/exceptions.py:class MissingOptionalDependencyError(OpenFFError):  # deprecated ...
openff/utilities/exceptions.py:class MissingOptionalDependency(MissingOptionalDependencyError):
```

`OpenFFException` is [not used](https://github.com/search?q=openffexception&type=Code) outside of this package so I won't go through a deprecation cycle.

## Questions

## Status
- [x] Ready to go