### PR TITLE
 Expose `MissingOptionalDependencyError` at module level

### DIFF
--- a/openff/utilities/__init__.py
+++ b/openff/utilities/__init__.py
@@ -1,5 +1,8 @@
 from openff.utilities._version import get_versions  # type: ignore
-from openff.utilities.exceptions import MissingOptionalDependency
+from openff.utilities.exceptions import (
+    MissingOptionalDependency,
+    MissingOptionalDependencyError,
+)
 from openff.utilities.provenance import get_ambertools_version
 from openff.utilities.testing import skip_if_missing, skip_if_missing_exec
 from openff.utilities.utilities import (


### PR DESCRIPTION
I forgot to ensure `from openff.utilities import MissingOptionalDependencyError` works