### PR TITLE
Remove deprecated `MissingOptionalDependency` exception

### DIFF
--- a/openff/utilities/__init__.py
+++ b/openff/utilities/__init__.py
@@ -1,7 +1,5 @@
 from openff.utilities._version import get_versions  # type: ignore
-from openff.utilities.exceptions import (
-    MissingOptionalDependencyError,
-)
+from openff.utilities.exceptions import MissingOptionalDependencyError
 from openff.utilities.provenance import get_ambertools_version
 from openff.utilities.testing import skip_if_missing, skip_if_missing_exec
 from openff.utilities.utilities import (

--- a/openff/utilities/__init__.py
+++ b/openff/utilities/__init__.py
@@ -1,6 +1,5 @@
 from openff.utilities._version import get_versions  # type: ignore
 from openff.utilities.exceptions import (
-    MissingOptionalDependency,
     MissingOptionalDependencyError,
 )
 from openff.utilities.provenance import get_ambertools_version

--- a/openff/utilities/exceptions.py
+++ b/openff/utilities/exceptions.py
@@ -44,12 +44,3 @@ class MissingOptionalDependencyError(OpenFFError):
 
         self.library_name = library_name
         self.license_issue = license_issue
-
-
-class MissingOptionalDependency(MissingOptionalDependencyError):
-    import warnings
-
-    warnings.warn(
-        "MissingOptionalDependency is deprecated. Use MissingOptionalDependencyError instead.",
-        DeprecationWarning,
-    )

--- a/openff/utilities/tests/test_exceptions.py
+++ b/openff/utilities/tests/test_exceptions.py
@@ -1,9 +1,6 @@
 import pytest
 
-from openff.utilities.exceptions import (
-    MissingOptionalDependencyError,
-    OpenFFError,
-)
+from openff.utilities.exceptions import MissingOptionalDependencyError, OpenFFError
 
 
 def test_exceptions():

--- a/openff/utilities/tests/test_exceptions.py
+++ b/openff/utilities/tests/test_exceptions.py
@@ -1,7 +1,6 @@
 import pytest
 
 from openff.utilities.exceptions import (
-    MissingOptionalDependency,
     MissingOptionalDependencyError,
     OpenFFError,
 )
@@ -22,9 +21,3 @@ def test_exceptions():
 
     with pytest.raises(OpenFFError):
         raise MissingOptionalDependencyError("numpy")
-
-
-def test_missing_optional_dependency_deprecation():
-    with pytest.raises(MissingOptionalDependency):
-        with pytest.warns(UserWarning, match="DEP"):
-            raise MissingOptionalDependency("foobar")


### PR DESCRIPTION
I thought I was being useful in gracefully deprecating `MissingOptionalDependency` but it turns out the main effect was emitting a deprecation warning - since it was imported in `openff/utilities/__init__.py`. This change simples removes it from existence, which fixes that. I can't find uses in the wild, therefore I expect zero impact of this change being including in an upcoming release: https://cs.github.com/?scopeName=All+repos&scope=&q=from+openff.utilities+import+MissingOptionalDependency


Demonstration that the warning is no longer emitted:
```shell
(openff-interchange-env) [openff-utilities] mamba list | grep utilities
forcefield-utilities      0.2.1              pyhd8ed1ab_0    conda-forge
openff-utilities          0.1.5              pyh6c4a22f_0    conda-forge
(openff-interchange-env) [openff-utilities] pytest openff        8:55:06  ☁  remove-deprecated-exception ☀
=========================================== test session starts ===========================================
platform darwin -- Python 3.9.13, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/mattthompson/software/openff-utilities
plugins: anyio-3.6.1, xdist-2.5.0, forked-1.4.0, nbval-0.9.6, cov-3.0.0
collected 12 items

openff/utilities/tests/test_exceptions.py .                                                         [  8%]
openff/utilities/tests/test_provenance.py .s                                                        [ 25%]
openff/utilities/tests/test_testing_utilities.py .                                                  [ 33%]
openff/utilities/tests/test_utilities.py ......ss                                                   [100%]

============================================ warnings summary =============================================
../../mambaforge/envs/openff-interchange-env/lib/python3.9/site-packages/openff/utilities/exceptions.py:52
  /Users/mattthompson/mambaforge/envs/openff-interchange-env/lib/python3.9/site-packages/openff/utilities/exceptions.py:52: DeprecationWarning: MissingOptionalDependency is deprecated. Use MissingOptionalDependencyError instead.
    warnings.warn(

openff/utilities/tests/test_testing_utilities.py::test_skips
  /Users/mattthompson/mambaforge/envs/openff-interchange-env/lib/python3.9/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.
    warnings.warn("Setuptools is replacing distutils.")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================ 9 passed, 3 skipped, 2 warnings in 2.20s =================================
(openff-interchange-env) [openff-utilities] python -m pip install -e .
Obtaining file:///Users/mattthompson/software/openff-utilities
  Preparing metadata (setup.py) ... done
Installing collected packages: openff-utilities
  Attempting uninstall: openff-utilities
    Found existing installation: openff-utilities 0.1.5
    Uninstalling openff-utilities-0.1.5:
      Successfully uninstalled openff-utilities-0.1.5
  Running setup.py develop for openff-utilities
Successfully installed openff-utilities-0.1.5+12.g5253ae1
(openff-interchange-env) [openff-utilities] pytest openff        8:55:23  ☁  remove-deprecated-exception ☀
=========================================== test session starts ===========================================
platform darwin -- Python 3.9.13, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/mattthompson/software/openff-utilities
plugins: anyio-3.6.1, xdist-2.5.0, forked-1.4.0, nbval-0.9.6, cov-3.0.0
collected 12 items

openff/utilities/tests/test_exceptions.py .                                                         [  8%]
openff/utilities/tests/test_provenance.py .s                                                        [ 25%]
openff/utilities/tests/test_testing_utilities.py .                                                  [ 33%]
openff/utilities/tests/test_utilities.py ......ss                                                   [100%]

============================================ warnings summary =============================================
openff/utilities/tests/test_testing_utilities.py::test_skips
  /Users/mattthompson/mambaforge/envs/openff-interchange-env/lib/python3.9/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.
    warnings.warn("Setuptools is replacing distutils.")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================= 9 passed, 3 skipped, 1 warning in 2.10s =================================