### PR TITLE
Add `get_data_dir_path`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,8 +79,7 @@ jobs:
 
     - name: Run mypy
       run: |
-        mypy --namespace-packages -p "openff.utilities" \
-          --strict --show-error-codes --implicit-reexport
+        mypy -p "openff.utilities" --strict --show-error-codes --implicit-reexport
 
     - name: Run a test with OpenEye toolkits installed but NOT licensed
       if: matrix.openeye == true

--- a/openff/utilities/tests/test_utilities.py
+++ b/openff/utilities/tests/test_utilities.py
@@ -5,6 +5,7 @@ import pytest
 from openff.utilities.exceptions import MissingOptionalDependencyError
 from openff.utilities.testing import skip_if_missing
 from openff.utilities.utilities import (
+    get_data_dir_path,
     get_data_file_path,
     has_executable,
     has_package,
@@ -31,24 +32,50 @@ def compare_paths(path_1: str, path_2: str) -> bool:
     return os.path.normpath(path_1) == os.path.normpath(path_2)
 
 
+def test_get_data_dir_path():
+    """Tests that the `get_data_dir_path` can correctly find
+    data directories.
+    """
+
+    # Test a path which should exist.
+    data_file_path = get_data_dir_path("data/more", package_name="openff.utilities")
+    assert os.path.isdir(data_file_path)
+
+    # Ensure a double-checking through data/ takes place
+    data_file_path = get_data_dir_path("more", package_name="openff.utilities")
+    assert os.path.isdir(data_file_path)
+
+    # Test a path which should not exist.
+    with pytest.raises(NotADirectoryError):
+        get_data_dir_path("missing", package_name="openff.utilities")
+
+    # Test that a file directory raises NotaDirectoryError
+    with pytest.raises(NotADirectoryError):
+        get_data_dir_path("data/data.dat", package_name="openff.utilities")
+
+
 def test_get_data_file_path():
     """Tests that the `get_data_file_path` can correctly find
     data files.
     """
 
     # Test a path which should exist.
-    data_file_path = get_data_file_path("data.dat", package_name="openff.utilities")
-    assert os.path.isfile(data_file_path)
-
-    # Ensure a double-checking through data/ takes place
     data_file_path = get_data_file_path(
         "data/data.dat", package_name="openff.utilities"
     )
     assert os.path.isfile(data_file_path)
 
+    # Ensure a double-checking through data/ takes place
+    data_file_path = get_data_file_path("data.dat", package_name="openff.utilities")
+    assert os.path.isfile(data_file_path)
+
     # Test a path which should not exist.
     with pytest.raises(FileNotFoundError):
         get_data_file_path("missing.file", package_name="openff.utilities")
+
+    # Test that a directory raises FileNotFoundError
+    with pytest.raises(FileNotFoundError):
+        get_data_file_path("data/", package_name="openff.utilities")
 
 
 def test_temporary_cd():

--- a/openff/utilities/utilities.py
+++ b/openff/utilities/utilities.py
@@ -4,9 +4,12 @@ import os
 from contextlib import contextmanager
 from functools import wraps
 from tempfile import TemporaryDirectory
-from typing import Any, Callable, Generator, Literal, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Generator, Literal, Optional, TypeVar
 
 from openff.utilities.exceptions import MissingOptionalDependencyError
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
 
@@ -216,16 +219,18 @@ def get_data_dir_path(relative_path: str, package_name: str) -> str:
     """
     from importlib_resources import files
 
-    file_path = files(package_name) / relative_path
+    dir_path: "Path" = files(package_name) / relative_path
 
-    if file_path.is_dir():
-        return file_path.as_posix()
+    if dir_path.is_dir():
+        pass
     elif (files(package_name) / "data" / relative_path).is_dir():
-        return (files(package_name) / "data" / relative_path).as_posix()
+        dir_path = files(package_name) / "data" / relative_path
     else:
         raise NotADirectoryError(
             f"Directory {relative_path} not found in {package_name}."
         )
+
+    return dir_path.as_posix()
 
 
 def get_data_file_path(relative_path: str, package_name: str) -> str:
@@ -258,7 +263,7 @@ def get_data_file_path(relative_path: str, package_name: str) -> str:
     """
     from importlib_resources import files
 
-    file_path = files(package_name) / relative_path
+    file_path: "Path" = files(package_name) / relative_path
 
     if not file_path.is_file():
         try_path = files(package_name) / f"data/{relative_path}"
@@ -267,4 +272,4 @@ def get_data_file_path(relative_path: str, package_name: str) -> str:
         else:
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), file_path)
 
-    return file_path.as_posix()  # type: ignore
+    return file_path.as_posix()

--- a/openff/utilities/utilities.py
+++ b/openff/utilities/utilities.py
@@ -187,6 +187,47 @@ def temporary_cd(directory_path: Optional[str] = None) -> Generator[None, None, 
         os.chdir(old_directory)
 
 
+def get_data_dir_path(relative_path: str, package_name: str) -> str:
+    """Get the full path to a directory within a module's tree.
+
+    If no directory is found at `relative_path`, a second attempt will be made
+    with `data/` preprended. If no directory is found at path, a NotADirectoryError
+    is raised.
+
+    Parameters
+    ----------
+    relative_path : str
+        The relative path of the file to load.
+    package_name : str
+        The name of the package in which a file is to be loaded, i.e. "openff.toolkit" or "openff.evaluator".
+
+    Returns
+    -------
+        The absolute path to the file.
+
+    Raises
+    ------
+    NotADirectoryError
+
+    See Also
+    --------
+    get_data_file_path, for getting the path to a particular file in a data directory.
+
+    """
+    from importlib_resources import files
+
+    file_path = files(package_name) / relative_path
+
+    if file_path.is_dir():
+        return str(file_path)
+    elif (files(package_name) / "data" / relative_path).is_dir():
+        return str(files(package_name) / "data" / relative_path)
+    else:
+        raise NotADirectoryError(
+            f"Directory {relative_path} not found in {package_name}."
+        )
+
+
 def get_data_file_path(relative_path: str, package_name: str) -> str:
     """Get the full path to one of the files in the data directory.
 
@@ -209,6 +250,11 @@ def get_data_file_path(relative_path: str, package_name: str) -> str:
     Raises
     ------
     FileNotFoundError
+
+    See Also
+    --------
+    get_data_dir_path, for getting the path to a directory instead of an individual file.
+
     """
     from importlib_resources import files
 

--- a/openff/utilities/utilities.py
+++ b/openff/utilities/utilities.py
@@ -219,9 +219,9 @@ def get_data_dir_path(relative_path: str, package_name: str) -> str:
     file_path = files(package_name) / relative_path
 
     if file_path.is_dir():
-        return str(file_path)
+        return file_path.as_posix()
     elif (files(package_name) / "data" / relative_path).is_dir():
-        return str(files(package_name) / "data" / relative_path)
+        return (files(package_name) / "data" / relative_path).as_posix()
     else:
         raise NotADirectoryError(
             f"Directory {relative_path} not found in {package_name}."


### PR DESCRIPTION
`get_data_dir_path` cannot be used to get the _directory_ of files, which is sometimes useful for testing.