### PR TITLE
Include `openeye.oedepict.OEDepictIsLicensed` in license checks

### DIFF
--- a/openff/utilities/tests/test_utilities.py
+++ b/openff/utilities/tests/test_utilities.py
@@ -155,11 +155,12 @@ def test_requires_oe_module():
     requires_oe_module("oechem")(dummy_function)()
 
 
-@skip_if_missing("openeye.oechem")
+@pytest.mark.parametrize('oe_module', ['oechem', 'oeiupac', 'oeomega', 'oequacpac', 'oedepict'])
+@skip_if_missing("openeye")
 @pytest.mark.skipif(
     "OE_LICENSE" in os.environ, reason="Requires an OpenEye license is NOT set up"
 )
-def test_requires_oe_module_installed_missing_license():
+def test_requires_oe_module_installed_missing_license(oe_module):
     """Tests that the ``requires_package`` utility behaves as expected while OpenEye toolkits are
     installed but no OpenEye license is set up."""
 
@@ -167,9 +168,9 @@ def test_requires_oe_module_installed_missing_license():
         pass
 
     with pytest.raises(MissingOptionalDependencyError) as error_info:
-        requires_oe_module("oechem")(dummy_function)()
+        requires_oe_module(oe_module)(dummy_function)()
 
-    assert "oechem" in str(error_info.value)
+    assert oe_module in str(error_info.value)
     assert "conda-forge" not in str(error_info.value)
 
 

--- a/openff/utilities/tests/test_utilities.py
+++ b/openff/utilities/tests/test_utilities.py
@@ -155,7 +155,9 @@ def test_requires_oe_module():
     requires_oe_module("oechem")(dummy_function)()
 
 
-@pytest.mark.parametrize('oe_module', ['oechem', 'oeiupac', 'oeomega', 'oequacpac', 'oedepict'])
+@pytest.mark.parametrize(
+    "oe_module", ["oechem", "oeiupac", "oeomega", "oequacpac", "oedepict"]
+)
 @skip_if_missing("openeye")
 @pytest.mark.skipif(
     "OE_LICENSE" in os.environ, reason="Requires an OpenEye license is NOT set up"

--- a/openff/utilities/utilities.py
+++ b/openff/utilities/utilities.py
@@ -114,6 +114,7 @@ def requires_oe_module(
                 "oequacpac": "OEQuacPacIsLicensed",
                 "oeiupac": "OEIUPACIsLicensed",
                 "oeomega": "OEOmegaIsLicensed",
+                "oedepict": "OEDepictIsLicensed",
             }
 
             is_licensed = getattr(oe_module, license_functions[module_name])()


### PR DESCRIPTION
https://github.com/openforcefield/openff-fragmenter/pull/164