### PR TITLE
Check for `micromamba` before checking for `conda`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,20 +10,21 @@ on:
 
 defaults:
   run:
-    shell: bash -l {0}
+    shell: bash -leo pipefail {0} {0}
 
 jobs:
   test:
-    name: ${{ matrix.os }}, 🐍=${{ matrix.python-version }}, AmberTools=${{ matrix.ambertools }}, OpenEye=${{ matrix.openeye }}
+    name: ${{ matrix.os }}, 🐍=${{ matrix.python-version }}, 🟠=${{ matrix.ambertools }}, 👁️=${{ matrix.openeye }}, 🐉=${{ matrix.mamba-executable }}
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         ambertools: [false, true]
         openeye: [false, true]
+        mamba-executable: ["mamba", "micromamba"]
         exclude:
           - python-version: "3.12"
             openeye: true
@@ -37,17 +38,26 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up conda environment
+    - name: Set up conda environment with micromamba
+      if: matrix.mamba-executable == 'micromamba'
       uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: devtools/conda-envs/test_env.yaml
         create-args: >-
           python=${{ matrix.python-version }}
 
+    - name: Set up conda environment with Mamba
+      if: matrix.mamba-executable == 'mamba'
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        environment-file: devtools/conda-envs/test_env.yaml
+        python-version: ${{ matrix.python-version }}
+        mamba-version: "*"
+  
     - name: Install AmberTools
       if: matrix.ambertools == true
       run: |
-        micromamba install --yes -c conda-forge ambertools
+        ${{ matrix.mamba-executable}} install --yes -c conda-forge ambertools
         python -c "from shutil import which; assert which('sqm') is not None"
 
     - name: Check AmberTools Missing
@@ -58,19 +68,18 @@ jobs:
     - name: Install OpenEye Toolkits
       if: matrix.openeye == true
       run: |
-        micromamba install --yes -c openeye openeye-toolkits
+        ${{ matrix.mamba-executable}} install --yes -c openeye openeye-toolkits
         python -c "from openeye import oechem"
 
     - name: Check OpenEye Toolkits missing
       if: matrix.openeye == false
-      run: |
-        python devtools/scripts/assert_openeye_not_found.py
+      run: python devtools/scripts/assert_openeye_not_found.py
 
     - name: Install package
       run: python -m pip install -e .
 
     - name: Environment Information
-      run: micromamba list
+      run: ${{ matrix.mamba-executable}} list
 
     - name: Run mypy
       if: ${{ matrix.python-version == 3.12 }}

--- a/openff/utilities/provenance.py
+++ b/openff/utilities/provenance.py
@@ -1,5 +1,4 @@
 import functools
-import re
 import subprocess
 from typing import Dict, Optional
 
@@ -19,12 +18,17 @@ def _get_conda_list_package_versions() -> Dict[str, str]:
     else:
         raise CondaExecutableNotFoundError()
 
-    output = subprocess.check_output([conda_executable, "list"]).decode().split("\n")
+    output = list(
+        filter(
+            lambda x: len(x) > 0,
+            subprocess.check_output([conda_executable, "list"]).decode().split("\n"),
+        )
+    )
 
     package_versions = {}
 
     for output_line in output[3:-1]:
-        package_name, package_version, *_ = re.split(" +", output_line)
+        package_name, package_version, *_ = output_line.split()
         package_versions[package_name] = package_version
 
     return package_versions

--- a/openff/utilities/provenance.py
+++ b/openff/utilities/provenance.py
@@ -10,12 +10,12 @@ def _get_conda_list_package_versions() -> Dict[str, str]:
     from openff.utilities.exceptions import CondaExecutableNotFoundError
     from openff.utilities.utilities import has_executable
 
-    if has_executable("mamba"):
+    if has_executable("micromamba"):
+        conda_executable = "micromamba"
+    elif has_executable("mamba"):
         conda_executable = "mamba"
     elif has_executable("conda"):
         conda_executable = "conda"
-    elif has_executable("micromamba"):
-        conda_executable = "micromamba"
     else:
         raise CondaExecutableNotFoundError()
 

--- a/openff/utilities/provenance.py
+++ b/openff/utilities/provenance.py
@@ -28,8 +28,8 @@ def _get_conda_list_package_versions() -> Dict[str, str]:
     package_versions = {}
 
     for output_line in output[3:-1]:
-    # The output format of `conda`/`mamba list` and `micromamba list` are different.
-    # See https://github.com/openforcefield/openff-utilities/issues/65
+        # The output format of `conda`/`mamba list` and `micromamba list` are different.
+        # See https://github.com/openforcefield/openff-utilities/issues/65
         package_name, package_version, *_ = output_line.split()
         package_versions[package_name] = package_version
 


### PR DESCRIPTION
## Description
For some reason, `setup-micromamba` has an alias to `conda`, so #65 is not tested in CI if `conda` is searched for first.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Reproduce #65
  - [x] Fix #65

## Status
- [ ] Ready to go