### PR TITLE
Warn on `conda list` failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,12 +97,13 @@ jobs:
 
     - name: Run unit tests
       run: |
-        pytest -v $COV openff/utilities/_tests/
+        pytest -v $COV openff/utilities/_tests/ -m leaky
+        pytest -v $COV openff/utilities/_tests/ -m "not leaky"
 
     - name: Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: true
         disable_search: true

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Welcome to openff-utilities's documentation!
    :caption: Contents:
 
    getting_started
+   releasehistory
    api
 
 

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -1,0 +1,18 @@
+# Release History
+
+Releases follow versioning as described in
+[PEP440](https://www.python.org/dev/peps/pep-0440/#final-releases), where
+
+* `major` increments denote a change that may break API compatibility with previous `major` releases
+* `minor` increments add features but do not break API compatibility
+* `micro` increments represent bugfix releases or improvements in documentation
+
+Dates are given in YYYY-MM-DD format.
+
+Please note that all releases prior to a version 1.0.0 are considered pre-releases and many API changes will come before a stable release.
+
+## Current development
+
+### Breaking changes and behavior changes
+
+* Failures to call `conda` or similar executables now raise a warning (`CondaExecutableNotFoundWarning`) instead of an exception (`CondaExecutableNotFoundError`)

--- a/openff/utilities/_tests/test_provenance.py
+++ b/openff/utilities/_tests/test_provenance.py
@@ -2,20 +2,60 @@ import importlib
 
 import pytest
 
-from openff.utilities.provenance import get_ambertools_version
+from openff.utilities.provenance import (
+    _get_conda_list_package_versions,
+    get_ambertools_version,
+)
+from openff.utilities.warnings import CondaExecutableNotFoundWarning
 
 
-def test_get_ambertools_version_found():
-    # Skip if ambertools is not installed.
+def mock_has_executable(executable_name: str) -> bool:
+    return False
+
+
+@pytest.mark.leaky
+def test_conda_unavailable_returns_empty_dict(monkeypatch):
+    """
+    Test that if `conda|etc. list` fails, with or without AmberTools (properly) installed,
+    get_ambertools_version returns `None`.
+
+    This test leaks! Do not run it alongside other tests! Select either it "pytest -m leaky"
+    or avoid it "pytest -m 'not leaky'"
+    """
+    with monkeypatch.context() as m, pytest.warns(
+        CondaExecutableNotFoundWarning,
+        match="No .* executable found",
+    ):
+        import openff.utilities.utilities
+
+        m.setattr(
+            openff.utilities.utilities,
+            "has_executable",
+            mock_has_executable,
+        )
+
+        # dummy-check that the mocking works
+        assert not openff.utilities.utilities.has_executable("pwd")
+
+        assert _get_conda_list_package_versions() == dict()
+
+
+def test_conda_available_get_ambertools_version_found():
+    # Skip if ambertools is not installed - sander would a better import test
+    # for AmberTools (since parmed could come from the standalone
+    # parmed package), however it's currently broken on ARM macs.
     pytest.importorskip("parmed")
 
-    assert get_ambertools_version() is not None
+    assert (
+        get_ambertools_version() is not None
+    ), f"note that len of package versions is {len(_get_conda_list_package_versions())}"
 
 
-def test_get_ambertools_version_not_found():
+def test_conda_available_get_ambertools_version_not_found():
     try:
         importlib.import_module("parmed")
     except ImportError:
+        assert len(_get_conda_list_package_versions()) > 0
         assert get_ambertools_version() is None
         return
 

--- a/openff/utilities/provenance.py
+++ b/openff/utilities/provenance.py
@@ -1,13 +1,17 @@
 import functools
 import subprocess
+import warnings
 from typing import Optional
 
 
 @functools.lru_cache
 def _get_conda_list_package_versions() -> dict[str, str]:
-    """Returns the versions of any packages found while executing `conda list`."""
-    from openff.utilities.exceptions import CondaExecutableNotFoundError
+    """
+    Returns the versions of any packages found while executing `conda list`.
+    If no conda executable is found, emits CondaExecutableNotFoundWarning
+    """
     from openff.utilities.utilities import has_executable
+    from openff.utilities.warnings import CondaExecutableNotFoundWarning
 
     if has_executable("micromamba"):
         conda_executable = "micromamba"
@@ -16,7 +20,11 @@ def _get_conda_list_package_versions() -> dict[str, str]:
     elif has_executable("conda"):
         conda_executable = "conda"
     else:
-        raise CondaExecutableNotFoundError()
+        warnings.warn(
+            "No conda/mamba/micromamba executable found. Unable to determine package versions.",
+            CondaExecutableNotFoundWarning,
+        )
+        return dict()
 
     output = list(
         filter(
@@ -37,6 +45,14 @@ def _get_conda_list_package_versions() -> dict[str, str]:
 
 
 def get_ambertools_version() -> Optional[str]:
-    """Attempts to retrieve the version of the currently installed AmberTools."""
+    """
+    Attempts to retrieve the version of the currently installed AmberTools.
+
+    There are two soft failure modes, each of which cause this function to return `None`:
+        1. If there is a failure calling `{conda|mamba|etc.} list`, the user is
+            warned by `_get_conda_list_package_versions` and this function returns `None`.
+        2. If there is a failure calling `{conda|mamba|etc.} list`, this function
+            still returns `None`, but without a warning associated with the above failure.
+    """
 
     return _get_conda_list_package_versions().get("ambertools", None)

--- a/openff/utilities/warnings.py
+++ b/openff/utilities/warnings.py
@@ -1,0 +1,4 @@
+class CondaExecutableNotFoundWarning(UserWarning):
+    """
+    A conda (or mamba/micromamba) executable is not found.
+    """


### PR DESCRIPTION
## Description
Resolves #89

`get_ambertools_version` should return `None` in these cases: https://github.com/openforcefield/openff-utilities/blob/b3e6016a4569823743e45e38bf38dc882e4a6ab5/openff/utilities/provenance.py#L42

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Warn on `conda list` failures
  - [x] Test

## Questions
- [ ] Question1

## Status
- [ ] Ready to go