### PR TITLE
Use stdlib `importlib.resources`

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -5,7 +5,6 @@ dependencies:
     # Base depends
   - python
   - pip
-  - importlib_resources
 
     # Testing
   - pytest

--- a/openff/utilities/__init__.py
+++ b/openff/utilities/__init__.py
@@ -4,6 +4,7 @@ from openff.utilities.exceptions import MissingOptionalDependencyError
 from openff.utilities.provenance import get_ambertools_version
 from openff.utilities.testing import skip_if_missing, skip_if_missing_exec
 from openff.utilities.utilities import (
+    get_data_dir_path,
     get_data_file_path,
     has_executable,
     has_package,
@@ -15,7 +16,7 @@ from openff.utilities.utilities import (
 __all__ = (
     "MissingOptionalDependencyError",
     "get_ambertools_version",
-    "get_data_file_path",
+    "get_data_dir_path",
     "has_executable",
     "has_package",
     "requires_oe_module",

--- a/openff/utilities/__init__.py
+++ b/openff/utilities/__init__.py
@@ -17,6 +17,7 @@ __all__ = (
     "MissingOptionalDependencyError",
     "get_ambertools_version",
     "get_data_dir_path",
+    "get_data_file_path",
     "has_executable",
     "has_package",
     "requires_oe_module",

--- a/openff/utilities/utilities.py
+++ b/openff/utilities/utilities.py
@@ -4,13 +4,14 @@ import os
 from collections.abc import Generator
 from contextlib import contextmanager
 from functools import wraps
+from importlib.resources import as_file, files
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, TypeVar
 
 from openff.utilities.exceptions import MissingOptionalDependencyError
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    pass
 
 # https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
 
@@ -213,18 +214,15 @@ def get_data_dir_path(relative_path: str, package_name: str) -> str:
     get_data_file_path, for getting the path to a particular file in a data directory.
 
     """
-    from importlib.resources import files
+    with as_file(files(package_name)) as dir_path:
+        if dir_path.is_dir():
+            return dir_path.as_posix()
 
-    dir_path: Path = files(package_name) / relative_path
+    with as_file(files(package_name) / "data" / relative_path) as dir_path:
+        if dir_path.is_dir():
+            return dir_path.as_posix()
 
-    if dir_path.is_dir():
-        pass
-    elif (files(package_name) / "data" / relative_path).is_dir():
-        dir_path = files(package_name) / "data" / relative_path
-    else:
-        raise NotADirectoryError(f"Directory {relative_path} not found in {package_name}.")
-
-    return dir_path.as_posix()
+    raise NotADirectoryError(f"Directory {relative_path} not found in {package_name}.")
 
 
 def get_data_file_path(relative_path: str, package_name: str) -> str:
@@ -255,15 +253,12 @@ def get_data_file_path(relative_path: str, package_name: str) -> str:
     get_data_dir_path, for getting the path to a directory instead of an individual file.
 
     """
-    from importlib.resources import files
+    with as_file(files(package_name) / relative_path) as file_path:
+        if file_path.is_file():
+            return file_path.as_posix()
 
-    file_path: Path = files(package_name) / relative_path
+    with as_file(files(package_name) / "data" / relative_path) as file_path:
+        if file_path.is_file():
+            return file_path.as_posix()
 
-    if not file_path.is_file():
-        try_path = files(package_name) / f"data/{relative_path}"
-        if try_path.is_file():
-            file_path = try_path
-        else:
-            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), file_path)
-
-    return file_path.as_posix()
+    raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), file_path)

--- a/openff/utilities/utilities.py
+++ b/openff/utilities/utilities.py
@@ -213,7 +213,7 @@ def get_data_dir_path(relative_path: str, package_name: str) -> str:
     get_data_file_path, for getting the path to a particular file in a data directory.
 
     """
-    from importlib_resources import files
+    from importlib.resources import files
 
     dir_path: Path = files(package_name) / relative_path
 
@@ -255,7 +255,7 @@ def get_data_file_path(relative_path: str, package_name: str) -> str:
     get_data_dir_path, for getting the path to a directory instead of an individual file.
 
     """
-    from importlib_resources import files
+    from importlib.resources import files
 
     file_path: Path = files(package_name) / relative_path
 

--- a/openff/utilities/utilities.py
+++ b/openff/utilities/utilities.py
@@ -6,12 +6,9 @@ from contextlib import contextmanager
 from functools import wraps
 from importlib.resources import as_file, files
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, TypeVar
+from typing import Any, Callable, Literal, Optional, TypeVar
 
 from openff.utilities.exceptions import MissingOptionalDependencyError
-
-if TYPE_CHECKING:
-    pass
 
 # https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
 
@@ -214,7 +211,7 @@ def get_data_dir_path(relative_path: str, package_name: str) -> str:
     get_data_file_path, for getting the path to a particular file in a data directory.
 
     """
-    with as_file(files(package_name)) as dir_path:
+    with as_file(files(package_name) / relative_path) as dir_path:
         if dir_path.is_dir():
             return dir_path.as_posix()
 


### PR DESCRIPTION
## Description
There's no reason to use this backport anymore

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Use `importlib.resources` instead of `importlib_resources` in tests
  - [x] Drop dependency

## Status
- [ ] Ready to go