### PR TITLE
Make `MissingOptionalDependencyError` also inherit from `ImportError`

### DIFF
--- a/openff/utilities/exceptions.py
+++ b/openff/utilities/exceptions.py
@@ -2,7 +2,7 @@ class OpenFFError(BaseException):
     """The base exception from which most custom exceptions in openff-utilities should inherit."""
 
 
-class MissingOptionalDependencyError(OpenFFError):
+class MissingOptionalDependencyError(OpenFFError, ImportError):
     """An exception raised when an optional dependency is required
     but cannot be found.
 


### PR DESCRIPTION
## Description
This exception should really inherit from `ImportError` as it previously did: https://github.com/openforcefield/openff-toolkit/blob/0.10.7/openff/toolkit/utils/exceptions.py#L18

See also https://github.com/openforcefield/openff-toolkit/issues/1157#issuecomment-2744419016

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Make `MissingOptionalDependencyError` also inherit from `ImportError`

## Status
- [ ] Ready to go